### PR TITLE
Fix failing tests due to old tag declaration

### DIFF
--- a/backend/src/api/endpoints/analysis.py
+++ b/backend/src/api/endpoints/analysis.py
@@ -66,7 +66,6 @@ async def annotation_occurrences(
 
 @router.post(
     "/annotated_segments",
-    tags=tags,
     response_model=List[AnnotatedSegment],
     summary="Returns AnnotationSegments.",
     description="Returns AnnotationSegments.",


### PR DESCRIPTION
There was an old tag declaration that slipped in during a rebase, I think. 