### PR TITLE
Use 0.0.0.0 as backend address when updating openapi spec

### DIFF
--- a/frontend/updateAPI.js
+++ b/frontend/updateAPI.js
@@ -23,7 +23,7 @@ if (fs.existsSync(openapiFilePath)) {
 
 // 2. download new openapi json file
 http
-  .get(`http://localhost:${port}/openapi.json`, (res) => {
+  .get(`http://0.0.0.0:${port}/openapi.json`, (res) => {
     const { statusCode } = res;
     const contentType = res.headers["content-type"];
 


### PR DESCRIPTION
On systems using IPv6, connecting to `localhost` errors because the backend listens on `0.0.0.0`, which is an IPv4 address, but `localhost` resolves to the IPv6 address `::1`.