### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
This automatically configures editors to use the correct indentation for YAML files, making setup for future developers easier.

See https://editorconfig.org/ for more information.