### PR TITLE
Remove random JWT Secret examples

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,7 +13,8 @@ DWISE_BACKEND_CONFIG=configs/default_localhost_dev.yaml
 
 # Authentication settings
 JWT_TTL=10080
-JWT_SECRET=f5b73acd6d6776350bce963bbcd2853fb5de00a4a4a081280ce1123b4a69aea9
+# Use `pwgen` to generate a secret or use any long random string
+JWT_SECRET=
 JWT_ALGO=HS256
 
 # Backend settings

--- a/backend/src/app/core/security.py
+++ b/backend/src/app/core/security.py
@@ -1,5 +1,3 @@
-import binascii
-import os
 from datetime import datetime, timedelta
 from typing import Dict
 
@@ -15,12 +13,6 @@ __password_ctx = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 __algo = conf.api.auth.jwt.algo
 __ttl = int(conf.api.auth.jwt.ttl)
 __jwt_secret = conf.api.auth.jwt.secret
-
-if not __jwt_secret or __jwt_secret == "":
-    logger.warning("JWT Secret not provided! Generating 32 bit secret")
-    __secret = binascii.hexlify(os.urandom(32))
-else:
-    __secret = conf.api.auth.jwt.secret
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:

--- a/backend/src/app/core/startup.py
+++ b/backend/src/app/core/startup.py
@@ -3,6 +3,7 @@ import random
 import time
 import traceback
 
+import config
 from loguru import logger
 
 
@@ -49,6 +50,8 @@ def startup(sql_echo: bool = False, reset_data: bool = False) -> None:
 
     # noinspection PyUnresolvedReferences
     try:
+        config.verify_config()
+
         # start and init services
         __init_services__(
             create_database_and_tables=not startup_in_progress,

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -20,3 +20,12 @@ logger.add(sys.stderr, level=conf.logging.level.upper())
 #            level=conf.logging.level.upper())
 
 logger.info(f"Loaded config '{__conf_file__}'")
+
+
+def verify_config():
+    jwt_secret = conf.api.auth.jwt.secret
+    print(jwt_secret)
+    if not jwt_secret or jwt_secret == "":
+        raise Exception(
+            "JWT Secret not set! Please provide a valid JWT Secret using the JWT_SECRET environment variable."
+        )

--- a/backend/src/configs/default.yaml
+++ b/backend/src/configs/default.yaml
@@ -13,7 +13,7 @@ api:
       token_url: /authentication/login
       ttl: ${oc.env:JWT_TTL, 600} # seconds
       algo: ${oc.env:JWT_ALGO, HS256}
-      secret: ${oc.env:JWT_SECRET, "c7c802ec8df3f2661a3c64d7f617be89e93cb334fb282409e1df555543742bf2"}
+      secret: ${oc.env:JWT_SECRET, ""}
 
 ray:
   protocol: ${oc.env:RAY_PROTOCOL, http}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -22,7 +22,8 @@ DWTS_FRONTEND_DOCKER_VERSION=latest
 
 # Authentication settings
 JWT_TTL=10080
-JWT_SECRET=f5b73acd6d6776350bce963bbcd2853fb5de00a4a4a081280ce1123b4a69aea9
+# Use `pwgen` to generate a secret or use any long random string
+JWT_SECRET=
 
 # Backend / Celery settings
 API_PORT=5500


### PR DESCRIPTION
- Prevent unaware users from using these public secrets in production
- Prevent false positives from the gitguardian check