### PR TITLE
Tell ruff where to find first-party code

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,3 +1,5 @@
+src = ["backend/src"]
+
 [lint]
 
 # I: isort-compatible import sorting

--- a/backend/src/alembic/env.py
+++ b/backend/src/alembic/env.py
@@ -1,13 +1,14 @@
 from logging.config import fileConfig
 from os import environ
 
+from sqlalchemy import engine_from_config, pool
+
 # When autogenerating migrations, alembic looks at our ORM models.
 # it's important to import all models so alembic won't try to
 # drop tables for models that weren't imported.
 import app.core.db.import_all_orms  # noqa: F401
 from alembic import context
 from app.core.data.orm.orm_base import ORMBase
-from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/backend/src/alembic/versions/5f42e48e0730_initialize_database.py
+++ b/backend/src/alembic/versions/5f42e48e0730_initialize_database.py
@@ -8,8 +8,9 @@ Create Date: 2023-11-24 11:38:13.155628
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from alembic import op
 from loguru import logger
+
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "5f42e48e0730"

--- a/backend/src/alembic/versions/fa0b606ae578_add_sourcedocumentdata.py
+++ b/backend/src/alembic/versions/fa0b606ae578_add_sourcedocumentdata.py
@@ -8,8 +8,9 @@ Create Date: 2023-11-08 14:42:44.947147
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
+
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "fa0b606ae578"

--- a/backend/src/api/dependencies.py
+++ b/backend/src/api/dependencies.py
@@ -1,5 +1,12 @@
 from typing import Annotated, Any, AsyncGenerator, Dict, Optional
 
+from fastapi import Depends, Query, Request
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError
+from pydantic import ValidationError
+from sqlalchemy.orm import Session
+
+from api.util import credentials_exception
 from app.core.authorization.authorization_service import (
     AuthorizationCheck,
     AuthorizationService,
@@ -12,13 +19,6 @@ from app.core.data.orm.user import UserORM
 from app.core.db.sql_service import SQLService
 from app.core.security import decode_jwt
 from config import conf
-from fastapi import Depends, Query, Request
-from fastapi.security import OAuth2PasswordBearer
-from jose import JWTError
-from pydantic import ValidationError
-from sqlalchemy.orm import Session
-
-from api.util import credentials_exception
 
 # instantiate here to so that it is reusable for consecutive calls
 reusable_oauth2_scheme = OAuth2PasswordBearer(tokenUrl=conf.api.auth.jwt.token_url)

--- a/backend/src/api/endpoints/analysis.py
+++ b/backend/src/api/endpoints/analysis.py
@@ -1,5 +1,9 @@
 from typing import Dict, List
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session
 from app.core.analysis.analysis_service import AnalysisService
 from app.core.data.crud.source_document_metadata import crud_sdoc_meta
 from app.core.data.dto.analysis import (
@@ -14,10 +18,6 @@ from app.core.data.dto.filter import Filter
 from app.core.data.dto.search import SimSearchQuery, SimSearchSentenceHit
 from app.core.search.elasticsearch_service import ElasticSearchService
 from app.core.search.search_service import SearchService
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session
 
 router = APIRouter(
     prefix="/analysis", dependencies=[Depends(get_current_user)], tags=["analysis"]

--- a/backend/src/api/endpoints/analysis_table.py
+++ b/backend/src/api/endpoints/analysis_table.py
@@ -1,15 +1,15 @@
 from typing import List, Optional
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session
 from app.core.data.crud.analysis_table import crud_analysis_table
 from app.core.data.dto.analysis_table import (
     AnalysisTableCreate,
     AnalysisTableRead,
     AnalysisTableUpdate,
 )
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session
 
 router = APIRouter(
     prefix="/analysisTable",

--- a/backend/src/api/endpoints/annotation_document.py
+++ b/backend/src/api/endpoints/annotation_document.py
@@ -1,5 +1,14 @@
 from typing import Dict, List, Optional, Union
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import (
+    get_current_user,
+    get_db_session,
+    resolve_code_param,
+    skip_limit_params,
+)
 from app.core.data.crud.annotation_document import crud_adoc
 from app.core.data.crud.bbox_annotation import crud_bbox_anno
 from app.core.data.crud.span_annotation import crud_span_anno
@@ -18,15 +27,6 @@ from app.core.data.dto.span_annotation import (
     SpanAnnotationReadResolved,
 )
 from app.core.data.dto.span_group import SpanGroupRead
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import (
-    get_current_user,
-    get_db_session,
-    resolve_code_param,
-    skip_limit_params,
-)
 
 router = APIRouter(
     prefix="/adoc",

--- a/backend/src/api/endpoints/authentication.py
+++ b/backend/src/api/endpoints/authentication.py
@@ -1,5 +1,11 @@
 from typing import Optional
 
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_db_session
+from api.util import credentials_exception
 from app.core.data.crud.user import crud_user
 from app.core.data.dto.user import (
     UserAuthorizationHeaderData,
@@ -9,12 +15,6 @@ from app.core.data.dto.user import (
 )
 from app.core.mail.mail_service import MailService
 from app.core.security import generate_jwt
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi.security import OAuth2PasswordRequestForm
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_db_session
-from api.util import credentials_exception
 
 router = APIRouter(prefix="/authentication", tags=["authentication"])
 

--- a/backend/src/api/endpoints/bbox_annotation.py
+++ b/backend/src/api/endpoints/bbox_annotation.py
@@ -1,5 +1,10 @@
 from typing import List, Optional, Union
 
+from fastapi import APIRouter, Depends
+from requests import Session
+
+from api.dependencies import get_current_user, get_db_session, resolve_code_param
+from api.util import get_object_memos
 from app.core.data.crud.bbox_annotation import crud_bbox_anno
 from app.core.data.crud.memo import crud_memo
 from app.core.data.dto.bbox_annotation import (
@@ -10,11 +15,6 @@ from app.core.data.dto.bbox_annotation import (
 )
 from app.core.data.dto.code import CodeRead
 from app.core.data.dto.memo import AttachedObjectType, MemoCreate, MemoInDB, MemoRead
-from fastapi import APIRouter, Depends
-from requests import Session
-
-from api.dependencies import get_current_user, get_db_session, resolve_code_param
-from api.util import get_object_memos
 
 router = APIRouter(
     prefix="/bbox", dependencies=[Depends(get_current_user)], tags=["bboxAnnotation"]

--- a/backend/src/api/endpoints/code.py
+++ b/backend/src/api/endpoints/code.py
@@ -1,15 +1,15 @@
 from typing import List, Optional
 
-from app.core.data.crud.code import crud_code
-from app.core.data.crud.current_code import crud_current_code
-from app.core.data.crud.memo import crud_memo
-from app.core.data.dto.code import CodeCreate, CodeRead, CodeUpdate
-from app.core.data.dto.memo import AttachedObjectType, MemoCreate, MemoInDB, MemoRead
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from api.dependencies import get_current_user, get_db_session
 from api.util import get_object_memos
+from app.core.data.crud.code import crud_code
+from app.core.data.crud.current_code import crud_current_code
+from app.core.data.crud.memo import crud_memo
+from app.core.data.dto.code import CodeCreate, CodeRead, CodeUpdate
+from app.core.data.dto.memo import AttachedObjectType, MemoCreate, MemoInDB, MemoRead
 
 router = APIRouter(
     prefix="/code", dependencies=[Depends(get_current_user)], tags=["code"]

--- a/backend/src/api/endpoints/crawler.py
+++ b/backend/src/api/endpoints/crawler.py
@@ -1,11 +1,11 @@
 from typing import List
 
-from app.celery.background_jobs import prepare_and_start_crawling_job_async
-from app.core.data.crawler.crawler_service import CrawlerService
-from app.core.data.dto.crawler_job import CrawlerJobParameters, CrawlerJobRead
 from fastapi import APIRouter, Depends
 
 from api.dependencies import get_current_user
+from app.celery.background_jobs import prepare_and_start_crawling_job_async
+from app.core.data.crawler.crawler_service import CrawlerService
+from app.core.data.dto.crawler_job import CrawlerJobParameters, CrawlerJobRead
 
 router = APIRouter(
     prefix="/crawler", dependencies=[Depends(get_current_user)], tags=["crawler"]

--- a/backend/src/api/endpoints/document_tag.py
+++ b/backend/src/api/endpoints/document_tag.py
@@ -1,5 +1,10 @@
 from typing import List, Optional
 
+from fastapi import APIRouter, Depends
+from requests import Session
+
+from api.dependencies import get_current_user, get_db_session
+from api.util import get_object_memos
 from app.core.data.crud.document_tag import crud_document_tag
 from app.core.data.crud.memo import crud_memo
 from app.core.data.dto.document_tag import (
@@ -10,11 +15,6 @@ from app.core.data.dto.document_tag import (
 )
 from app.core.data.dto.memo import AttachedObjectType, MemoCreate, MemoInDB, MemoRead
 from app.core.data.dto.source_document import SourceDocumentRead
-from fastapi import APIRouter, Depends
-from requests import Session
-
-from api.dependencies import get_current_user, get_db_session
-from api.util import get_object_memos
 
 router = APIRouter(
     prefix="/doctag", dependencies=[Depends(get_current_user)], tags=["documentTag"]

--- a/backend/src/api/endpoints/export.py
+++ b/backend/src/api/endpoints/export.py
@@ -1,9 +1,9 @@
-from app.celery.background_jobs import prepare_and_start_export_job_async
-from app.core.data.dto.export_job import ExportJobParameters, ExportJobRead
-from app.core.data.export.export_service import ExportService
 from fastapi import APIRouter, Depends
 
 from api.dependencies import get_current_user
+from app.celery.background_jobs import prepare_and_start_export_job_async
+from app.core.data.dto.export_job import ExportJobParameters, ExportJobRead
+from app.core.data.export.export_service import ExportService
 
 router = APIRouter(
     prefix="/export", dependencies=[Depends(get_current_user)], tags=["export"]

--- a/backend/src/api/endpoints/feedback.py
+++ b/backend/src/api/endpoints/feedback.py
@@ -1,14 +1,14 @@
 from typing import List, Optional
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session
 from app.core.data.crud.user import crud_user
 from app.core.data.dto.feedback import FeedbackCreate, FeedbackRead
 from app.core.data.dto.user import UserRead
 from app.core.db.redis_service import RedisService
 from app.core.mail.mail_service import MailService
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session
 
 router = APIRouter(
     prefix="/feedback", dependencies=[Depends(get_current_user)], tags=["feedback"]

--- a/backend/src/api/endpoints/memo.py
+++ b/backend/src/api/endpoints/memo.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
-from app.core.data.crud.memo import crud_memo
-from app.core.data.dto.memo import MemoRead, MemoUpdate
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from api.dependencies import get_current_user, get_db_session
+from app.core.data.crud.memo import crud_memo
+from app.core.data.dto.memo import MemoRead, MemoUpdate
 
 router = APIRouter(
     prefix="/memo", dependencies=[Depends(get_current_user)], tags=["memo"]

--- a/backend/src/api/endpoints/metadata.py
+++ b/backend/src/api/endpoints/metadata.py
@@ -1,15 +1,15 @@
 from typing import Optional
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session
 from app.core.data.crud.source_document_metadata import crud_sdoc_meta
 from app.core.data.dto.source_document_metadata import (
     SourceDocumentMetadataCreate,
     SourceDocumentMetadataRead,
     SourceDocumentMetadataUpdate,
 )
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session
 
 router = APIRouter(
     prefix="/metadata", dependencies=[Depends(get_current_user)], tags=["metadata"]

--- a/backend/src/api/endpoints/prepro.py
+++ b/backend/src/api/endpoints/prepro.py
@@ -1,5 +1,9 @@
 from typing import List, Optional
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session
 from app.core.data.crud.preprocessing_job import crud_prepro_job
 from app.core.data.crud.preprocessing_job_payload import crud_prepro_job_payload
 from app.core.data.crud.project import crud_project
@@ -10,10 +14,6 @@ from app.core.data.dto.preprocessing_job import PreprocessingJobRead
 from app.core.data.dto.preprocessing_job_payload import PreprocessingJobPayloadRead
 from app.core.db.redis_service import RedisService
 from app.preprocessing.preprocessing_service import PreprocessingService
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session
 
 router = APIRouter(
     prefix="/prepro", dependencies=[Depends(get_current_user)], tags=["prepro"]

--- a/backend/src/api/endpoints/project.py
+++ b/backend/src/api/endpoints/project.py
@@ -1,5 +1,15 @@
 from typing import Dict, List, Optional
 
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from sqlalchemy.orm import Session
+
+from api.dependencies import (
+    get_current_user,
+    get_db_session,
+    is_authorized,
+    skip_limit_params,
+)
+from api.util import get_object_memos
 from app.core.data.crud.action import crud_action
 from app.core.data.crud.code import crud_code
 from app.core.data.crud.document_tag import crud_document_tag
@@ -22,16 +32,6 @@ from app.core.data.dto.source_document_metadata import SourceDocumentMetadataRea
 from app.core.data.dto.user import UserRead
 from app.core.search.elasticsearch_service import ElasticSearchService
 from app.preprocessing.preprocessing_service import PreprocessingService
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
-from sqlalchemy.orm import Session
-
-from api.dependencies import (
-    get_current_user,
-    get_db_session,
-    is_authorized,
-    skip_limit_params,
-)
-from api.util import get_object_memos
 
 router = APIRouter(
     prefix="/project",

--- a/backend/src/api/endpoints/search.py
+++ b/backend/src/api/endpoints/search.py
@@ -1,5 +1,9 @@
 from typing import Dict, List
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session, skip_limit_params
 from app.core.data.crud.source_document import crud_sdoc
 from app.core.data.dto.search import (
     KeywordStat,
@@ -19,10 +23,6 @@ from app.core.data.dto.search import (
 )
 from app.core.search.elasticsearch_service import ElasticSearchService
 from app.core.search.search_service import SearchService
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session, skip_limit_params
 
 router = APIRouter(
     prefix="/search", dependencies=[Depends(get_current_user)], tags=["search"]

--- a/backend/src/api/endpoints/source_document.py
+++ b/backend/src/api/endpoints/source_document.py
@@ -1,5 +1,10 @@
 from typing import List, Optional
 
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session
+from api.util import get_object_memos
 from app.core.data.crud.annotation_document import crud_adoc
 from app.core.data.crud.memo import crud_memo
 from app.core.data.crud.source_document import crud_sdoc
@@ -23,11 +28,6 @@ from app.core.data.dto.source_document_metadata import (
 )
 from app.core.data.repo.repo_service import RepoService
 from app.core.search.elasticsearch_service import ElasticSearchService
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session
-from api.util import get_object_memos
 
 router = APIRouter(
     prefix="/sdoc", dependencies=[Depends(get_current_user)], tags=["sourceDocument"]

--- a/backend/src/api/endpoints/span_annotation.py
+++ b/backend/src/api/endpoints/span_annotation.py
@@ -1,5 +1,10 @@
 from typing import List, Optional, Union
 
+from fastapi import APIRouter, Depends
+from requests import Session
+
+from api.dependencies import get_current_user, get_db_session, resolve_code_param
+from api.util import get_object_memos
 from app.core.data.crud.memo import crud_memo
 from app.core.data.crud.span_annotation import crud_span_anno
 from app.core.data.dto.code import CodeRead
@@ -11,11 +16,6 @@ from app.core.data.dto.span_annotation import (
     SpanAnnotationUpdateWithCodeId,
 )
 from app.core.data.dto.span_group import SpanGroupRead
-from fastapi import APIRouter, Depends
-from requests import Session
-
-from api.dependencies import get_current_user, get_db_session, resolve_code_param
-from api.util import get_object_memos
 
 router = APIRouter(
     prefix="/span", dependencies=[Depends(get_current_user)], tags=["spanAnnotation"]

--- a/backend/src/api/endpoints/span_group.py
+++ b/backend/src/api/endpoints/span_group.py
@@ -1,5 +1,9 @@
 from typing import List, Optional, Union
 
+from fastapi import APIRouter, Depends
+from requests import Session
+
+from api.dependencies import get_current_user, get_db_session, resolve_code_param
 from app.core.data.crud.span_group import crud_span_group
 from app.core.data.dto.code import CodeRead
 from app.core.data.dto.span_annotation import (
@@ -7,10 +11,6 @@ from app.core.data.dto.span_annotation import (
     SpanAnnotationReadResolved,
 )
 from app.core.data.dto.span_group import SpanGroupCreate, SpanGroupRead, SpanGroupUpdate
-from fastapi import APIRouter, Depends
-from requests import Session
-
-from api.dependencies import get_current_user, get_db_session, resolve_code_param
 
 router = APIRouter(
     prefix="/spangroup", dependencies=[Depends(get_current_user)], tags=["spanGroup"]

--- a/backend/src/api/endpoints/user.py
+++ b/backend/src/api/endpoints/user.py
@@ -1,5 +1,9 @@
 from typing import Dict, List, Optional
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session, skip_limit_params
 from app.core.data.crud.annotation_document import crud_adoc
 from app.core.data.crud.memo import crud_memo
 from app.core.data.crud.user import crud_user
@@ -9,10 +13,6 @@ from app.core.data.dto.memo import MemoRead
 from app.core.data.dto.project import ProjectRead
 from app.core.data.dto.user import UserRead, UserUpdate
 from app.core.data.orm.user import UserORM
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session, skip_limit_params
 
 router = APIRouter(
     prefix="/user", dependencies=[Depends(get_current_user)], tags=["user"]

--- a/backend/src/api/endpoints/whiteboard.py
+++ b/backend/src/api/endpoints/whiteboard.py
@@ -1,15 +1,15 @@
 from typing import List, Optional
 
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from api.dependencies import get_current_user, get_db_session
 from app.core.data.crud.whiteboard import crud_whiteboard
 from app.core.data.dto.whiteboard import (
     WhiteboardCreate,
     WhiteboardRead,
     WhiteboardUpdate,
 )
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from api.dependencies import get_current_user, get_db_session
 
 router = APIRouter(
     prefix="/whiteboard", dependencies=[Depends(get_current_user)], tags=["whiteboard"]

--- a/backend/src/api/util.py
+++ b/backend/src/api/util.py
@@ -1,5 +1,9 @@
 from typing import List, Optional, Union
 
+from fastapi import HTTPException
+from loguru import logger
+from starlette import status
+
 from app.core.data.dto.memo import AttachedObjectType, MemoInDB, MemoRead
 from app.core.data.orm.bbox_annotation import BBoxAnnotationORM
 from app.core.data.orm.code import CodeORM
@@ -7,9 +11,6 @@ from app.core.data.orm.document_tag import DocumentTagORM
 from app.core.data.orm.project import ProjectORM
 from app.core.data.orm.source_document import SourceDocumentORM
 from app.core.data.orm.span_annotation import SpanAnnotationORM
-from fastapi import HTTPException
-from loguru import logger
-from starlette import status
 
 credentials_exception = HTTPException(
     status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/src/app/celery/celery_worker.py
+++ b/backend/src/app/celery/celery_worker.py
@@ -2,6 +2,7 @@ import inspect
 from typing import Dict
 
 from celery import Celery
+
 from config import conf
 
 cc = conf.celery

--- a/backend/src/app/core/analysis/analysis_service.py
+++ b/backend/src/app/core/analysis/analysis_service.py
@@ -1,8 +1,8 @@
 from typing import List
 
-from api.util import get_object_memos
 from sqlalchemy import and_, func
 
+from api.util import get_object_memos
 from app.core.data.crud.project import crud_project
 from app.core.data.dto.analysis import (
     AnnotatedSegment,

--- a/backend/src/app/core/data/crawler/spiders/spider_base.py
+++ b/backend/src/app/core/data/crawler/spiders/spider_base.py
@@ -5,6 +5,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import scrapy
+
 from app.core.data.crawler.crawled_item import CrawledItem
 from app.core.data.crawler.utils import slugify
 

--- a/backend/src/app/core/data/crud/code.py
+++ b/backend/src/app/core/data/crud/code.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Optional
 
 import srsly
-from config import conf
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
@@ -13,6 +12,7 @@ from app.core.data.dto.code import CodeCreate, CodeRead, CodeUpdate
 from app.core.data.dto.current_code import CurrentCodeCreate
 from app.core.data.orm.code import CodeORM
 from app.util.color import get_next_color
+from config import conf
 
 
 class CRUDCode(CRUDBase[CodeORM, CodeCreate, CodeUpdate]):

--- a/backend/src/app/core/data/export/export_service.py
+++ b/backend/src/app/core/data/export/export_service.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
+from loguru import logger
+from sqlalchemy.orm import Session
+
 from app.core.data.crud.annotation_document import crud_adoc
 from app.core.data.crud.code import crud_code
 from app.core.data.crud.document_tag import crud_document_tag
@@ -49,8 +52,6 @@ from app.core.data.repo.repo_service import RepoService
 from app.core.db.redis_service import RedisService
 from app.core.db.sql_service import SQLService
 from app.util.singleton_meta import SingletonMeta
-from loguru import logger
-from sqlalchemy.orm import Session
 
 
 class NoDataToExportError(Exception):

--- a/backend/src/app/core/data/repo/repo_service.py
+++ b/backend/src/app/core/data/repo/repo_service.py
@@ -8,7 +8,6 @@ from typing import List, Optional, Tuple, Union
 from zipfile import ZipFile
 
 import magic
-from config import conf
 from fastapi import HTTPException, UploadFile
 from loguru import logger
 
@@ -21,6 +20,7 @@ from app.core.data.dto.source_document import (
     SourceDocumentRead,
 )
 from app.util.singleton_meta import SingletonMeta
+from config import conf
 
 # TODO Flo: Currently only supports localhost but in future it could be that processes running on a different host use
 #           this service...

--- a/backend/src/app/core/db/redis_service.py
+++ b/backend/src/app/core/db/redis_service.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import List, Optional, Union
 
 import redis
-from config import conf
 from loguru import logger
 
 from app.core.data.dto.crawler_job import (
@@ -14,6 +13,7 @@ from app.core.data.dto.crawler_job import (
 from app.core.data.dto.export_job import ExportJobCreate, ExportJobRead, ExportJobUpdate
 from app.core.data.dto.feedback import FeedbackCreate, FeedbackRead
 from app.util.singleton_meta import SingletonMeta
+from config import conf
 
 
 class RedisService(metaclass=SingletonMeta):

--- a/backend/src/app/core/db/sql_service.py
+++ b/backend/src/app/core/db/sql_service.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 from typing import Generator
 
-from config import conf
 from loguru import logger
 from pydantic import PostgresDsn
 from sqlalchemy import create_engine
@@ -12,6 +11,7 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 from app.core.data.orm.orm_base import ORMBase
 from app.core.db.import_all_orms import *  # noqa: F401, F403
 from app.util.singleton_meta import SingletonMeta
+from config import conf
 
 
 class SQLService(metaclass=SingletonMeta):

--- a/backend/src/app/core/mail/mail_service.py
+++ b/backend/src/app/core/mail/mail_service.py
@@ -1,10 +1,10 @@
-from config import conf
 from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
 from pydantic import EmailStr
 
 from app.core.data.dto.feedback import FeedbackRead
 from app.core.data.dto.user import UserRead
 from app.util.singleton_meta import SingletonMeta
+from config import conf
 
 
 class MailService(metaclass=SingletonMeta):

--- a/backend/src/app/core/search/elasticsearch_service.py
+++ b/backend/src/app/core/search/elasticsearch_service.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union
 
 import srsly
-from config import conf
 from elasticsearch import Elasticsearch, helpers
 from loguru import logger
 from omegaconf import OmegaConf
@@ -22,6 +21,7 @@ from app.core.data.dto.search import (
 )
 from app.core.data.dto.source_document import SourceDocumentKeywords
 from app.util.singleton_meta import SingletonMeta
+from config import conf
 
 
 class NoSuchSourceDocumentInElasticSearchError(Exception):

--- a/backend/src/app/core/search/simsearch_service.py
+++ b/backend/src/app/core/search/simsearch_service.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import weaviate
-from config import conf
 from loguru import logger
 
 from app.core.data.crud.source_document import crud_sdoc
@@ -23,6 +22,7 @@ from app.preprocessing.ray_model_worker.dto.clip import (
     ClipTextEmbeddingInput,
 )
 from app.util.singleton_meta import SingletonMeta
+from config import conf
 
 
 class SimSearchService(metaclass=SingletonMeta):

--- a/backend/src/app/core/security.py
+++ b/backend/src/app/core/security.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
 from typing import Dict
 
-from config import conf
 from jose import jwt
 from loguru import logger
 from passlib.context import CryptContext
 
 from app.core.data.dto.user import UserRead
+from config import conf
 
 __password_ctx = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 

--- a/backend/src/app/core/startup.py
+++ b/backend/src/app/core/startup.py
@@ -3,8 +3,9 @@ import random
 import time
 import traceback
 
-import config
 from loguru import logger
+
+import config
 from migration.migrate import run_required_migrations
 
 
@@ -131,12 +132,12 @@ def __init_services__(
 
 
 def __create_system_user__() -> None:
-    from config import conf
     from pydantic import EmailStr
 
     from app.core.data.crud.user import crud_user
     from app.core.data.dto.user import UserCreate
     from app.core.db.sql_service import SQLService
+    from config import conf
 
     with SQLService().db_session() as db_session:
         if not crud_user.exists(db=db_session, id=1):

--- a/backend/src/app/preprocessing/pipeline/steps/audio/convert_to_pcm.py
+++ b/backend/src/app/preprocessing/pipeline/steps/audio/convert_to_pcm.py
@@ -1,7 +1,8 @@
 import ffmpeg
+from loguru import logger
+
 from app.preprocessing.pipeline.model.audio.preproaudiodoc import PreProAudioDoc
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
-from loguru import logger
 
 
 def convert_to_pcm(cargo: PipelineCargo) -> PipelineCargo:

--- a/backend/src/app/preprocessing/pipeline/steps/audio/create_and_store_transcript_file.py
+++ b/backend/src/app/preprocessing/pipeline/steps/audio/create_and_store_transcript_file.py
@@ -1,6 +1,7 @@
+from loguru import logger
+
 from app.preprocessing.pipeline.model.audio.preproaudiodoc import PreProAudioDoc
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
-from loguru import logger
 
 
 def create_and_store_transcript_file(cargo: PipelineCargo) -> PipelineCargo:

--- a/backend/src/app/preprocessing/pipeline/steps/audio/create_ffmpeg_probe_audio_metadata.py
+++ b/backend/src/app/preprocessing/pipeline/steps/audio/create_ffmpeg_probe_audio_metadata.py
@@ -1,4 +1,5 @@
 import ffmpeg
+
 from app.preprocessing.pipeline.model.audio.preproaudiodoc import PreProAudioDoc
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 

--- a/backend/src/app/preprocessing/pipeline/steps/audio/generate_automatic_transcription.py
+++ b/backend/src/app/preprocessing/pipeline/steps/audio/generate_automatic_transcription.py
@@ -1,3 +1,5 @@
+from loguru import logger
+
 from app.preprocessing.pipeline.model.audio.preproaudiodoc import PreProAudioDoc
 from app.preprocessing.pipeline.model.audio.wordleveltranscription import (
     WordLevelTranscription,
@@ -8,7 +10,6 @@ from app.preprocessing.ray_model_worker.dto.whisper import (
     WhisperFilePathInput,
     WhisperTranscriptionOutput,
 )
-from loguru import logger
 
 rms = RayModelService()
 

--- a/backend/src/app/preprocessing/pipeline/steps/audio/generate_webp_thumbnail_for_audio.py
+++ b/backend/src/app/preprocessing/pipeline/steps/audio/generate_webp_thumbnail_for_audio.py
@@ -2,6 +2,7 @@ import wave
 
 import matplotlib.pyplot as plt
 import numpy as np
+
 from app.core.data.repo.repo_service import RepoService
 from app.preprocessing.pipeline.model.audio.preproaudiodoc import PreProAudioDoc
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo

--- a/backend/src/app/preprocessing/pipeline/steps/audio/write_ppad_to_database.py
+++ b/backend/src/app/preprocessing/pipeline/steps/audio/write_ppad_to_database.py
@@ -1,5 +1,8 @@
 import json
 
+from loguru import logger
+from sqlalchemy.orm import Session
+
 from app.core.data.crud.annotation_document import crud_adoc
 from app.core.data.crud.source_document import crud_sdoc
 from app.core.data.crud.source_document_link import crud_sdoc_link
@@ -14,8 +17,6 @@ from app.core.data.repo.repo_service import RepoService
 from app.core.db.sql_service import SQLService
 from app.preprocessing.pipeline.model.audio.preproaudiodoc import PreProAudioDoc
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
-from loguru import logger
-from sqlalchemy.orm import Session
 
 repo: RepoService = RepoService()
 sql: SQLService = SQLService()

--- a/backend/src/app/preprocessing/pipeline/steps/common/remove_erroneous_sdoc.py
+++ b/backend/src/app/preprocessing/pipeline/steps/common/remove_erroneous_sdoc.py
@@ -1,9 +1,10 @@
+from loguru import logger
+
 from app.core.data.crud.source_document import crud_sdoc
 from app.core.data.dto.source_document import SDocStatus
 from app.core.data.repo.repo_service import RepoService
 from app.core.db.sql_service import SQLService
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
-from loguru import logger
 
 repo: RepoService = RepoService()
 sql: SQLService = SQLService()

--- a/backend/src/app/preprocessing/pipeline/steps/image/convert_to_webp_and_generate_thumbnail.py
+++ b/backend/src/app/preprocessing/pipeline/steps/image/convert_to_webp_and_generate_thumbnail.py
@@ -1,7 +1,8 @@
+from PIL import Image
+
 from app.core.data.repo.repo_service import RepoService
 from app.preprocessing.pipeline.model.image.preproimagedoc import PreProImageDoc
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
-from PIL import Image
 
 repo: RepoService = RepoService()
 

--- a/backend/src/app/preprocessing/pipeline/steps/image/create_image_metadata.py
+++ b/backend/src/app/preprocessing/pipeline/steps/image/create_image_metadata.py
@@ -1,7 +1,8 @@
-from app.preprocessing.pipeline.model.image.preproimagedoc import PreProImageDoc
-from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from PIL import Image
 from PIL.ExifTags import TAGS
+
+from app.preprocessing.pipeline.model.image.preproimagedoc import PreProImageDoc
+from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 
 
 def create_image_metadata(cargo: PipelineCargo) -> PipelineCargo:

--- a/backend/src/app/preprocessing/pipeline/steps/image/write_ppid_to_database.py
+++ b/backend/src/app/preprocessing/pipeline/steps/image/write_ppid_to_database.py
@@ -1,5 +1,9 @@
 from typing import List
 
+from loguru import logger
+from psycopg2 import OperationalError
+from sqlalchemy.orm import Session
+
 from app.core.data.crud.annotation_document import crud_adoc
 from app.core.data.crud.bbox_annotation import crud_bbox_anno
 from app.core.data.crud.code import crud_code
@@ -18,9 +22,6 @@ from app.core.db.sql_service import SQLService
 from app.preprocessing.pipeline.model.image.preproimagedoc import PreProImageDoc
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.util.color import get_next_color
-from loguru import logger
-from psycopg2 import OperationalError
-from sqlalchemy.orm import Session
 
 repo: RepoService = RepoService()
 sql: SQLService = SQLService()

--- a/backend/src/app/preprocessing/pipeline/steps/text/apply_html_source_mapping_with_custom_html_tags.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/apply_html_source_mapping_with_custom_html_tags.py
@@ -1,7 +1,8 @@
+from loguru import logger
+
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
 from app.util.string_builder import StringBuilder
-from loguru import logger
 
 
 def apply_html_source_mapping_with_custom_html_tags(

--- a/backend/src/app/preprocessing/pipeline/steps/text/clean_html.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/clean_html.py
@@ -5,11 +5,12 @@ from typing import Dict, List
 
 import lxml.html.clean as clean
 import magic
-from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
-from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
 from bs4 import BeautifulSoup
 from loguru import logger
 from readability import Document
+
+from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
+from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
 
 
 def clean_html_tags_and_attrs(

--- a/backend/src/app/preprocessing/pipeline/steps/text/create_html_content_file.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/create_html_content_file.py
@@ -1,7 +1,8 @@
+from loguru import logger
+
 from app.core.data.repo.repo_service import RepoService
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
-from loguru import logger
 
 repo = RepoService()
 

--- a/backend/src/app/preprocessing/pipeline/steps/text/create_ppj_from_extracted_images.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/create_ppj_from_extracted_images.py
@@ -1,8 +1,9 @@
+from loguru import logger
+
 from app.core.data.repo.repo_service import RepoService
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
 from app.preprocessing.preprocessing_service import PreprocessingService
-from loguru import logger
 
 repo = RepoService()
 pps = PreprocessingService()

--- a/backend/src/app/preprocessing/pipeline/steps/text/detect_content_language.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/detect_content_language.py
@@ -1,7 +1,8 @@
-from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
-from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
 from langdetect import detect_langs
 from loguru import logger
+
+from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
+from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
 
 
 def detect_content_language(cargo: PipelineCargo) -> PipelineCargo:

--- a/backend/src/app/preprocessing/pipeline/steps/text/extract_content_in_html_from_word_or_pdf_docs.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/extract_content_in_html_from_word_or_pdf_docs.py
@@ -4,11 +4,12 @@ from uuid import uuid4
 
 import fitz
 import mammoth
+from bs4 import BeautifulSoup
+from loguru import logger
+
 from app.core.data.repo.repo_service import RepoService
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
-from bs4 import BeautifulSoup
-from loguru import logger
 
 repo = RepoService()
 

--- a/backend/src/app/preprocessing/pipeline/steps/text/extract_sdoc_links_from_html_of_mixed_documents.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/extract_sdoc_links_from_html_of_mixed_documents.py
@@ -1,10 +1,11 @@
 from typing import List
 
+from bs4 import BeautifulSoup
+
 from app.core.data.dto.source_document_link import SourceDocumentLinkCreate
 from app.core.data.repo.repo_service import RepoService
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
-from bs4 import BeautifulSoup
 
 repo: RepoService = RepoService()
 

--- a/backend/src/app/preprocessing/pipeline/steps/text/generate_named_entity_annotations.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/generate_named_entity_annotations.py
@@ -1,7 +1,8 @@
+from loguru import logger
+
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.autospan import AutoSpan
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
-from loguru import logger
 
 
 def generate_named_entity_annotations(cargo: PipelineCargo) -> PipelineCargo:

--- a/backend/src/app/preprocessing/pipeline/steps/text/generate_sentence_annotations.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/generate_sentence_annotations.py
@@ -1,7 +1,8 @@
+from loguru import logger
+
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.autospan import AutoSpan
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
-from loguru import logger
 
 
 def generate_sentence_annotations(cargo: PipelineCargo) -> PipelineCargo:

--- a/backend/src/app/preprocessing/pipeline/steps/text/generate_word_frequencies_and_keywords.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/generate_word_frequencies_and_keywords.py
@@ -1,8 +1,9 @@
 from collections import Counter
 
+from loguru import logger
+
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
-from loguru import logger
 
 
 def generate_word_frequncies_and_keywords(cargo: PipelineCargo) -> PipelineCargo:

--- a/backend/src/app/preprocessing/pipeline/steps/text/write_pptd_to_database.py
+++ b/backend/src/app/preprocessing/pipeline/steps/text/write_pptd_to_database.py
@@ -1,5 +1,9 @@
 import json
 
+from loguru import logger
+from psycopg2 import OperationalError
+from sqlalchemy.orm import Session
+
 from app.core.data.crud.annotation_document import crud_adoc
 from app.core.data.crud.code import crud_code
 from app.core.data.crud.source_document import crud_sdoc
@@ -21,9 +25,6 @@ from app.core.db.sql_service import SQLService
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.text.preprotextdoc import PreProTextDoc
 from app.util.color import get_next_color
-from loguru import logger
-from psycopg2 import OperationalError
-from sqlalchemy.orm import Session
 
 repo: RepoService = RepoService()
 sql: SQLService = SQLService()

--- a/backend/src/app/preprocessing/pipeline/steps/video/create_and_store_audio_stream_file.py
+++ b/backend/src/app/preprocessing/pipeline/steps/video/create_and_store_audio_stream_file.py
@@ -1,7 +1,8 @@
 import ffmpeg
+from loguru import logger
+
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.video.preprovideodoc import PreProVideoDoc
-from loguru import logger
 
 
 def create_and_store_audio_stream_file(cargo: PipelineCargo) -> PipelineCargo:

--- a/backend/src/app/preprocessing/pipeline/steps/video/create_ffmpeg_probe_video_metadata.py
+++ b/backend/src/app/preprocessing/pipeline/steps/video/create_ffmpeg_probe_video_metadata.py
@@ -1,4 +1,5 @@
 import ffmpeg
+
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.video.preprovideodoc import PreProVideoDoc
 

--- a/backend/src/app/preprocessing/pipeline/steps/video/generate_webp_thumbnail_for_video.py
+++ b/backend/src/app/preprocessing/pipeline/steps/video/generate_webp_thumbnail_for_video.py
@@ -1,11 +1,12 @@
 from io import BytesIO
 
 import ffmpeg
+from loguru import logger
+from PIL import Image
+
 from app.core.data.repo.repo_service import RepoService
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.video.preprovideodoc import PreProVideoDoc
-from loguru import logger
-from PIL import Image
 
 repo = RepoService()
 

--- a/backend/src/app/preprocessing/pipeline/steps/video/write_ppvd_to_database.py
+++ b/backend/src/app/preprocessing/pipeline/steps/video/write_ppvd_to_database.py
@@ -1,3 +1,6 @@
+from loguru import logger
+from sqlalchemy.orm import Session
+
 from app.core.data.crud.annotation_document import crud_adoc
 from app.core.data.crud.source_document import crud_sdoc
 from app.core.data.crud.source_document_link import crud_sdoc_link
@@ -12,8 +15,6 @@ from app.core.data.repo.repo_service import RepoService
 from app.core.db.sql_service import SQLService
 from app.preprocessing.pipeline.model.pipeline_cargo import PipelineCargo
 from app.preprocessing.pipeline.model.video.preprovideodoc import PreProVideoDoc
-from loguru import logger
-from sqlalchemy.orm import Session
 
 repo: RepoService = RepoService()
 sql: SQLService = SQLService()

--- a/backend/src/app/preprocessing/ray_model_service.py
+++ b/backend/src/app/preprocessing/ray_model_service.py
@@ -2,7 +2,6 @@ import sys
 from typing import Any, Dict, List
 
 import requests
-from config import conf
 from loguru import logger
 from requests import Response
 
@@ -26,6 +25,7 @@ from app.preprocessing.ray_model_worker.dto.whisper import (
     WhisperTranscriptionOutput,
 )
 from app.util.singleton_meta import SingletonMeta
+from config import conf
 
 
 class RayModelService(metaclass=SingletonMeta):

--- a/backend/src/app/preprocessing/ray_model_worker/models/blip2.py
+++ b/backend/src/app/preprocessing/ray_model_worker/models/blip2.py
@@ -1,11 +1,12 @@
 import logging
 
 import torch
-from config import build_ray_model_deployment_config, conf
 from dto.blip2 import Blip2FilePathInput, Blip2Output
 from PIL import Image
 from ray import serve
 from transformers import Blip2ForConditionalGeneration, Blip2Processor
+
+from config import build_ray_model_deployment_config, conf
 
 cc = conf.blip2
 

--- a/backend/src/app/preprocessing/ray_model_worker/models/clip.py
+++ b/backend/src/app/preprocessing/ray_model_worker/models/clip.py
@@ -1,7 +1,6 @@
 import logging
 
 import torch
-from config import build_ray_model_deployment_config, conf
 from dto.clip import (
     ClipEmbeddingOutput,
     ClipImageEmbeddingInput,
@@ -10,6 +9,8 @@ from dto.clip import (
 from PIL import Image
 from ray import serve
 from sentence_transformers import SentenceTransformer
+
+from config import build_ray_model_deployment_config, conf
 
 cc = conf.clip
 

--- a/backend/src/app/preprocessing/ray_model_worker/models/detr.py
+++ b/backend/src/app/preprocessing/ray_model_worker/models/detr.py
@@ -2,11 +2,12 @@ import logging
 from typing import List, Tuple
 
 import torch
-from config import build_ray_model_deployment_config, conf
 from dto.detr import DETRFilePathInput, DETRObjectDetectionOutput, ObjectBBox
 from PIL import Image
 from ray import serve
 from transformers import DetrFeatureExtractor, DetrForObjectDetection
+
+from config import build_ray_model_deployment_config, conf
 
 cc = conf.detr
 

--- a/backend/src/app/preprocessing/ray_model_worker/models/spacy.py
+++ b/backend/src/app/preprocessing/ray_model_worker/models/spacy.py
@@ -2,10 +2,11 @@ import logging
 from typing import Dict, List
 
 import spacy
-from config import build_ray_model_deployment_config, conf
 from dto.spacy import SpacyInput, SpacyPipelineOutput, SpacySpan, SpacyToken
 from ray import serve
 from spacy import Language
+
+from config import build_ray_model_deployment_config, conf
 
 cc = conf.spacy
 

--- a/backend/src/app/preprocessing/ray_model_worker/models/vit_gpt2.py
+++ b/backend/src/app/preprocessing/ray_model_worker/models/vit_gpt2.py
@@ -1,7 +1,6 @@
 import logging
 
 import torch
-from config import build_ray_model_deployment_config, conf
 from dto.vit_gpt2 import ViTGPT2FilePathInput, ViTGPT2Output
 from PIL import Image
 from ray import serve
@@ -10,6 +9,8 @@ from transformers import (
     VisionEncoderDecoderModel,
     ViTFeatureExtractor,
 )
+
+from config import build_ray_model_deployment_config, conf
 
 cc = conf.vit_gpt2
 

--- a/backend/src/app/preprocessing/ray_model_worker/models/whisper.py
+++ b/backend/src/app/preprocessing/ray_model_worker/models/whisper.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import torch
-from config import build_ray_model_deployment_config, conf
 from dto.whisper import (
     SegmentTranscription,
     WhisperFilePathInput,
@@ -15,6 +14,8 @@ from dto.whisper import (
 from faster_whisper import WhisperModel as wm
 from ray import serve
 from scipy.io import wavfile
+
+from config import build_ray_model_deployment_config, conf
 
 logger = logging.getLogger("ray.serve")
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,7 +3,6 @@
 
 import os
 
-from app.core.authorization.authorization_service import ForbiddenError
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -14,6 +13,8 @@ from loguru import logger
 from psycopg2.errors import UniqueViolation
 from sqlalchemy.exc import IntegrityError
 from uvicorn.main import uvicorn
+
+from app.core.authorization.authorization_service import ForbiddenError
 
 from app.core.startup import startup  # isort: skip
 

--- a/backend/src/migration/migrate.py
+++ b/backend/src/migration/migrate.py
@@ -1,5 +1,9 @@
 from typing import Set
 
+from loguru import logger
+from sqlalchemy import exists
+from sqlalchemy.orm import Session
+
 from alembic.command import upgrade
 from alembic.config import Config
 from app.core.data.crud.source_document_data import crud_sdoc_data
@@ -13,9 +17,6 @@ from app.core.data.orm.source_document_data import SourceDocumentDataORM
 from app.core.data.orm.version import VersionORM
 from app.core.db.sql_service import SQLService
 from app.core.search.elasticsearch_service import ElasticSearchService
-from loguru import logger
-from sqlalchemy import exists
-from sqlalchemy.orm import Session
 
 
 def run_required_migrations():

--- a/backend/src/test/api/endpoints/test_authentication.py
+++ b/backend/src/test/api/endpoints/test_authentication.py
@@ -3,6 +3,7 @@ from typing import Sequence, Set, Tuple
 
 import starlette.routing
 from fastapi.routing import APIRoute
+
 from main import app
 
 

--- a/backend/src/test/api/endpoints/test_general.py
+++ b/backend/src/test/api/endpoints/test_general.py
@@ -1,5 +1,6 @@
 import pytest
 from httpx import AsyncClient
+
 from main import app
 
 

--- a/backend/src/test/app/core/data/crud/test_code_crud.py
+++ b/backend/src/test/app/core/data/crud/test_code_crud.py
@@ -2,6 +2,7 @@ import random
 import string
 
 import pytest
+
 from api.util import get_object_memos
 from app.core.data.crud.code import crud_code
 from app.core.data.crud.crud_base import NoSuchElementError

--- a/backend/src/test/app/core/data/crud/test_project_crud.py
+++ b/backend/src/test/app/core/data/crud/test_project_crud.py
@@ -3,6 +3,8 @@ import string
 from typing import Any, Dict
 
 import pytest
+from sqlalchemy.exc import IntegrityError
+
 from app.core.data.crud.code import crud_code
 from app.core.data.crud.crud_base import NoSuchElementError
 from app.core.data.crud.memo import crud_memo
@@ -15,7 +17,6 @@ from app.core.data.dto.project import ProjectCreate, ProjectRead, ProjectUpdate
 from app.core.data.dto.user import UserCreate, UserRead
 from app.core.db.sql_service import SQLService
 from config import conf
-from sqlalchemy.exc import IntegrityError
 
 
 def get_number_of_system_codes() -> int:

--- a/backend/src/test/app/core/data/crud/test_user_crud.py
+++ b/backend/src/test/app/core/data/crud/test_user_crud.py
@@ -2,6 +2,7 @@ import random
 import string
 
 import pytest
+
 from app.core.data.crud.crud_base import NoSuchElementError
 from app.core.data.crud.user import crud_user
 from app.core.data.dto.code import CodeRead

--- a/backend/src/test/conftest.py
+++ b/backend/src/test/conftest.py
@@ -10,6 +10,7 @@ import sys
 from typing import Generator
 
 import pytest
+
 from app.core.startup import startup
 
 sys._called_from_test = True


### PR DESCRIPTION
Without this, ruff erroneously considered our own code as third-party code, leading to wrong import sort order.