### PR TITLE
Run migrations before startup script

### DIFF
--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -57,8 +57,8 @@ jobs:
           swap-size-gb: 10
       - uses: actions/checkout@v3
       - name: Start Docker Containers
+        working-directory: docker
         run: |
-          cd docker
           ./setup-folders.sh
           cp .env.example .env
           chmod -R a+rwx backend_repo/ models_cache/ spacy_models/ tika/
@@ -66,10 +66,12 @@ jobs:
           export GID=$(id -g)
           export API_PRODUCTION_WORKERS=0
           export RAY_CONFIG="./config_test_no_gpu.yaml"
+          # disable backend and frontend
+          export COMPOSE_PROFILES=
           docker compose -f compose-test.yml up -d --quiet-pull
           echo Waiting for containers to start...
           sleep 30
-          cd ..
-      - name: Run CRUD tests
+      - name: Run unit tests
+        working-directory: docker
         run: |
-          docker exec -i demo-dwts-backend-api-1 /opt/envs/dwts/bin/python -m pytest
+          docker compose -f compose-test.yml run -i dwts-backend-api /opt/envs/dwts/bin/python -m pytest

--- a/backend/src/app/core/db/sql_service.py
+++ b/backend/src/app/core/db/sql_service.py
@@ -23,7 +23,7 @@ class SQLService(metaclass=SingletonMeta):
                 password=conf.postgres.password,
                 host=conf.postgres.host,
                 port=int(conf.postgres.port),
-                path=f"/{conf.postgres.db}",
+                path=f"{conf.postgres.db}",
             )
 
             engine = create_engine(

--- a/backend/src/app/core/startup.py
+++ b/backend/src/app/core/startup.py
@@ -6,7 +6,6 @@ import traceback
 from loguru import logger
 
 import config
-from migration.migrate import run_required_migrations
 
 
 def startup(sql_echo: bool = False, reset_data: bool = False) -> None:
@@ -53,11 +52,6 @@ def startup(sql_echo: bool = False, reset_data: bool = False) -> None:
     # noinspection PyUnresolvedReferences
     try:
         config.verify_config()
-        # In production, multiple workers run in parallel, but
-        # we can not to run migrations in parallel.
-        # The block above should ensure that only one startup
-        # process is running at any given time.
-        run_required_migrations()
 
         # start and init services
         __init_services__(

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import IntegrityError
 from uvicorn.main import uvicorn
 
 from app.core.authorization.authorization_service import ForbiddenError
+from migration.migrate import run_required_migrations
 
 from app.core.startup import startup  # isort: skip
 
@@ -275,6 +276,12 @@ def main() -> None:
     assert (
         port is not None and isinstance(port, int) and port > 0
     ), "The API port has to be a positive integer! E.g. 8081"
+
+    # Migrations are usually run in the docker entrypoint script.
+    # When the backend is run in development mode outside a container,
+    # the `main` function we're in is used instead.
+    # In that case, we'll need to run the migrations now.
+    run_required_migrations()
 
     is_debug = conf.api.production_mode == "0"
 

--- a/backend/src/test/app/core/data/crud/test_project_crud.py
+++ b/backend/src/test/app/core/data/crud/test_project_crud.py
@@ -102,7 +102,7 @@ def test_create_remove_project(session: SQLService) -> None:
     description = "Test description"
 
     with session.db_session() as sess:
-        system_user = UserRead.from_orm(crud_user.read(sess, SYSTEM_USER_ID))
+        system_user = UserRead.model_validate(crud_user.read(sess, SYSTEM_USER_ID))
         id = crud_project.create(
             db=sess,
             create_dto=ProjectCreate(title=title, description=description),

--- a/backend/src/test/conftest.py
+++ b/backend/src/test/conftest.py
@@ -73,7 +73,7 @@ def project(session: SQLService, user: int) -> Generator[int, None, None]:
     description = "Test description"
 
     with session.db_session() as sess:
-        system_user = UserRead.from_orm(crud_user.read(sess, SYSTEM_USER_ID))
+        system_user = UserRead.model_validate(crud_user.read(sess, SYSTEM_USER_ID))
         id = crud_project.create(
             db=sess,
             create_dto=ProjectCreate(

--- a/backend/src/test/conftest.py
+++ b/backend/src/test/conftest.py
@@ -12,6 +12,7 @@ from typing import Generator
 import pytest
 
 from app.core.startup import startup
+from migration.migrate import run_required_migrations
 
 sys._called_from_test = True
 
@@ -19,6 +20,7 @@ sys._called_from_test = True
 # file once more manually, so it would be executed twice.
 STARTUP_DONE = bool(int(os.environ.get("STARTUP_DONE", "0")))
 if not STARTUP_DONE:
+    run_required_migrations()
     startup(reset_data=True)
     os.environ["STARTUP_DONE"] = "1"
 


### PR DESCRIPTION
Running migrations inside our startup process caused them to be run multiple times, once for each worker, in production. While this should be fine, it's better to run migrations only once before even starting the backend.