### PR TITLE
Fix login screen error for missing user

### DIFF
--- a/backend/src/app/core/data/crud/user.py
+++ b/backend/src/app/core/data/crud/user.py
@@ -32,7 +32,13 @@ class CRUDUser(CRUDBase[UserORM, UserCreate, UserUpdate]):
         return user
 
     def authenticate(self, db: Session, user_login: UserLogin) -> Optional[UserORM]:
-        user = self.read_by_email(db=db, email=user_login.username)
+        try:
+            user = self.read_by_email(db=db, email=user_login.username)
+        except NoSuchElementError:
+            # Don't tell users if the email or the password was wrong
+            # to prevent email guessing attacks
+            return None
+
         if not verify_password(
             plain_password=user_login.password, hashed_password=user.password
         ):


### PR DESCRIPTION
When the email specified during login didn't exist, the backend returned a 404 code which caused the frontend to say "server not available". It now returns 403 which results in the correct error message on the frontend, and prevents email guessing attacks via the login route as well.