### PR TITLE
Run CI on all pull requests

### DIFF
--- a/.github/workflows/backend_check_schema.yml
+++ b/.github/workflows/backend_check_schema.yml
@@ -1,9 +1,6 @@
 name: Check backend database schema
 on:
   pull_request:
-    branches:
-      - main
-      - mwp_v1
     paths:
       - "backend/**"
       - ".github/**"

--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -10,9 +10,6 @@ on:
       - ".github/**"
       - "docker/**"
   pull_request:
-    branches:
-      - main
-      - mwp_v1
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/update-openapi-spec.yml
+++ b/.github/workflows/update-openapi-spec.yml
@@ -1,10 +1,7 @@
 name: Update OpenAPI spec
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
+  # Triggers the workflow on pull request events
   pull_request:
-    branches:
-      - main
-      - mwp_v1
     paths:
       - "backend/**"
       - ".github/**"


### PR DESCRIPTION
Before this change, the CI would not run for PRs that had a base different than `mwp_v1`, even after the base was changed back to `mwp_v1`, which resulted in the CI not running in [this PR](https://github.com/uhh-lt/dwts/pull/259) although it should have run.