### PR TITLE
Always run alembic migrations during startup

### DIFF
--- a/backend/src/app/core/startup.py
+++ b/backend/src/app/core/startup.py
@@ -6,6 +6,7 @@ import traceback
 from loguru import logger
 
 import config
+from migration.migrate import run_required_migrations
 
 
 def startup(sql_echo: bool = False, reset_data: bool = False) -> None:
@@ -52,6 +53,11 @@ def startup(sql_echo: bool = False, reset_data: bool = False) -> None:
     # noinspection PyUnresolvedReferences
     try:
         config.verify_config()
+
+        if not startup_in_progress:
+            # If we're the first uvicorn worker to start,
+            # run database migrations
+            run_required_migrations()
 
         # start and init services
         __init_services__(

--- a/backend/src/backend_api_entrypoint.sh
+++ b/backend/src/backend_api_entrypoint.sh
@@ -12,8 +12,6 @@ API_PRODUCTION_WORKERS=${API_PRODUCTION_WORKERS:-10}
 # assert ray is reachable
 [ "${RAY_ENABLED}" = "True" ] && ./test_ray.sh
 
-python run_migrations.py
-
 if [ "${API_PRODUCTION_MODE}" -ge 1 ]; then
   # start api in production mode without hot reload and only X worker
   uvicorn --log-level "${LOG_LEVEL}" --port "${API_PORT}" --host "0.0.0.0" --workers "${API_PRODUCTION_WORKERS}" main:app

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -16,7 +16,6 @@ from sqlalchemy.exc import IntegrityError
 from uvicorn.main import uvicorn
 
 from app.core.authorization.authz_user import ForbiddenError
-from migration.migrate import run_required_migrations
 
 from app.core.startup import startup  # isort: skip
 
@@ -278,12 +277,6 @@ def main() -> None:
     assert (
         port is not None and isinstance(port, int) and port > 0
     ), "The API port has to be a positive integer! E.g. 8081"
-
-    # Migrations are usually run in the docker entrypoint script.
-    # When the backend is run in development mode outside a container,
-    # the `main` function we're in is used instead.
-    # In that case, we'll need to run the migrations now.
-    run_required_migrations()
 
     is_debug = conf.api.production_mode == "0"
 

--- a/backend/src/test/conftest.py
+++ b/backend/src/test/conftest.py
@@ -15,7 +15,6 @@ from fastapi.datastructures import Headers
 from app.core.authorization.authz_user import AuthzUser
 from app.core.data.orm.project import ProjectORM
 from app.core.startup import startup
-from migration.migrate import run_required_migrations
 
 os.environ["RAY_ENABLED"] = "False"
 
@@ -23,7 +22,6 @@ os.environ["RAY_ENABLED"] = "False"
 # file once more manually, so it would be executed twice.
 STARTUP_DONE = bool(int(os.environ.get("STARTUP_DONE", "0")))
 if not STARTUP_DONE:
-    run_required_migrations()
     startup(reset_data=True)
     os.environ["STARTUP_DONE"] = "1"
 


### PR DESCRIPTION
Before this change, starting the backend with a completely empty database would fail, because initializing all the services would require an already migrated database, and we would be running migrations only after initializing the services.

With this, alembic may be invoked multiple times during startup as uvicorn will start workers in batches, but that should not cause any problems.