### PR TITLE
Configure prettier pre-commit hook to run on .json files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,5 +31,5 @@ repos:
     rev: "v3.1.0"
     hooks:
       - id: prettier
-        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
+        files: \.([jt]sx?|json)$ # *.js, *.jsx, *.ts, *.tsx, *.json
         args: [--print-width, "120"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.envFile": "${workspaceFolder}/backend/.env",
-    "python.analysis.extraPaths": ["./backend/src"],
-    "python.autoComplete.extraPaths": ["./backend/src"]
+  "python.envFile": "${workspaceFolder}/backend/.env",
+  "python.analysis.extraPaths": ["./backend/src"],
+  "python.autoComplete.extraPaths": ["./backend/src"]
 }

--- a/frontend/generateAPI.js
+++ b/frontend/generateAPI.js
@@ -18,5 +18,5 @@ console.log(openapiOutput.toString("utf-8"));
 
 // 3. prettify file
 console.log(`Prettify generated code at ${openapiFolderPath}`);
-const prettierOutput = execSync(`prettier -w ${openapiFolderPath}`);
+const prettierOutput = execSync(`npx prettier --write ${openapiFolderPath}`);
 console.log(prettierOutput.toString("utf-8"));

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/frontend/updateAPI.js
+++ b/frontend/updateAPI.js
@@ -67,7 +67,7 @@ http
 
         // 5. prettify file
         console.log("Prettify openapi.json");
-        exec(`prettier -w ${openapiFilePath}`, (err, stdout, stderr) => {
+        exec(`npx prettier --write ${openapiFilePath}`, (err, stdout, stderr) => {
           if (err) {
             // node couldn't execute the command
             console.error("An error occured when trying to run prettier :(");

--- a/tools/readability/package.json
+++ b/tools/readability/package.json
@@ -1,16 +1,16 @@
 {
-    "dependencies": {
-        "@mozilla/readability": "^0.4.2",
-        "express": "^4.18.2",
-        "jsdom": "^16.7.0",
-        "minimist": "^1.2.7"
+  "dependencies": {
+    "@mozilla/readability": "^0.4.2",
+    "express": "^4.18.2",
+    "jsdom": "^16.7.0",
+    "minimist": "^1.2.7"
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": "latest"
     },
-    "eslintConfig": {
-        "parserOptions": {
-            "ecmaVersion": "latest"
-        },
-        "env": {
-            "es6": true
-        }
+    "env": {
+      "es6": true
     }
+  }
 }


### PR DESCRIPTION
Our openapi update scripts usually format the `openapi.json` file using prettier. This is now enforced by adding json files to our prettier pre-commit check.