### PR TITLE
Fix docs not being removed from weaviate

### DIFF
--- a/backend/src/app/core/data/crud/project.py
+++ b/backend/src/app/core/data/crud/project.py
@@ -21,6 +21,7 @@ from app.core.data.orm.project import ProjectORM
 from app.core.data.orm.user import UserORM
 from app.core.data.repo.repo_service import RepoService
 from app.core.db.sql_service import SQLService
+from app.core.search.simsearch_service import SimSearchService
 
 
 class CRUDProject(CRUDBase[ProjectORM, ProjectCreate, ProjectUpdate]):
@@ -67,6 +68,8 @@ class CRUDProject(CRUDBase[ProjectORM, ProjectCreate, ProjectUpdate]):
         proj_db_obj = super().remove(db=db, id=id)
         # 2) delete the files from repo
         RepoService().purge_project_data(proj_id=id)
+        # 3) Remove embeddings
+        SimSearchService().remove_all_project_embeddings(id)
 
         return proj_db_obj
 

--- a/backend/src/app/core/search/simsearch_service.py
+++ b/backend/src/app/core/search/simsearch_service.py
@@ -201,6 +201,16 @@ class SimSearchService(metaclass=SingletonMeta):
                 vector=image_emb,
             )
 
+    def remove_sdoc_from_index(self, doctype: str, sdoc_id: int):
+        match doctype:
+            case DocType.text:
+                self.remove_text_sdoc_from_index(sdoc_id)
+            case DocType.image:
+                self.remove_image_sdoc_from_index(sdoc_id)
+            case _:
+                # Other doctypes are not used for simsearch
+                pass
+
     def remove_image_sdoc_from_index(
         self,
         sdoc_id: int,
@@ -214,7 +224,6 @@ class SimSearchService(metaclass=SingletonMeta):
 
     def remove_text_sdoc_from_index(
         self,
-        proj_id: int,
         sdoc_id: int,
     ) -> None:
         obj_ids = self._get_sentence_object_ids_by_sdoc_id(sdoc_id=sdoc_id)


### PR DESCRIPTION
- When a single document is removed, remove it from weaviate
- When a whole project is removed, remove its documents from weaviate
- When all documents in a project are removed, remove them from weaviate. 
> [!NOTE]
> The last endpoint is unused at the moment, maybe we can remove it.