### PR TITLE
Add blip precision config, ray docker compose profile

### DIFF
--- a/backend/src/app/preprocessing/ray_model_worker/config.yaml
+++ b/backend/src/app/preprocessing/ray_model_worker/config.yaml
@@ -156,7 +156,7 @@ vit_gpt2:
 blip2:
   model: "salesforce/blip2-opt-2.7b"
   device: ${oc.env:RAY_PROCESSING_DEVICE_BLIP2, cuda}
-  precision_bit: 8 # 8/16/32
+  precision_bit: ${oc.env:RAY_BLIP2_PRECISION_BIT, 8} # 8/16/32
   image_captioning:
     max_caption_length: 16
     num_beams: 4

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,8 +1,8 @@
 COMPOSE_PROJECT_NAME=demo
 # If you're running the backend and frontend
 # outside of containers,
-# remove this line to disable their containers
-COMPOSE_PROFILES=backend,frontend
+# remove their profiles to disable their containers
+COMPOSE_PROFILES=backend,frontend,ray
 
 # Which user and group to use for running processes
 # inside containers.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -76,6 +76,9 @@ RAY_PROCESSING_DEVICE_WHISPER=cuda
 RAY_PROCESSING_DEVICE_DETR=cuda
 RAY_PROCESSING_DEVICE_VIT_GPT2=cuda
 RAY_PROCESSING_DEVICE_BLIP2=cuda
+# If operating blip2 on the cpu, this has to be 32
+# Otherwise, you can choose between 8, 16 and 32
+RAY_BLIP2_PRECISION_BIT=8
 RAY_PROCESSING_DEVICE_CLIP=cuda
 
 WEAVIATE_HOST=weaviate

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -190,6 +190,8 @@ services:
         reservations:
           devices:
             - capabilities: [gpu]
+    profiles:
+      - ray
 
   dwts-backend-api:
     image: uhhlt/dwts_backend:${DWTS_BACKEND_DOCKER_VERSION:-debian_dev_latest}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
   },
-  "include": ["src"]
+  "include": ["src"],
 }


### PR DESCRIPTION
When using blip2 on the CPU, it's necessary to set the precision to 32 bits.

Also, fix #316 since it loosely matched the topic of the first commit :D