### PR TITLE
Bugfix update_project api route

### DIFF
--- a/backend/src/app/core/data/crud/crud_base.py
+++ b/backend/src/app/core/data/crud/crud_base.py
@@ -88,7 +88,7 @@ class CRUDBase(Generic[ORMModelType, CreateDTOType, UpdateDTOType]):
         db_obj = self.read(db=db, id=id)
         before_state = self._get_action_state_from_orm(db_obj=db_obj)
 
-        obj_data = jsonable_encoder(db_obj)
+        obj_data = jsonable_encoder(db_obj.as_dict())
         update_data = update_dto.model_dump(exclude_unset=True)
         for field in obj_data:
             if field in update_data:

--- a/frontend/src/api/openapi/core/OpenAPI.ts
+++ b/frontend/src/api/openapi/core/OpenAPI.ts
@@ -20,7 +20,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
   BASE: "",
-  VERSION: "1.0.1",
+  VERSION: "1.0.2",
   WITH_CREDENTIALS: false,
   CREDENTIALS: "include",
   TOKEN: undefined,


### PR DESCRIPTION
After some digging i discovered the following problem:
When querying the database for the project the return value seems to be fine and can be interpret by the fastapi jsonable_encoder.
But when the method  _get_action_state_from_orm is called before the jsonable_encode the db_obj seems to change its state.
This is not obvious for me since the method only returns the db_obj as a dict.
If now the jsonable_encoder is called it ends in a RecursionError by the jsonable_encoder.

A quickfix is to convert the db_obj to a dict and then use the jsonable_encoder like in the PR.

There seems to be a known problem in the jsonable_encoder: https://github.com/tiangolo/fastapi/pull/10359